### PR TITLE
ignore identity

### DIFF
--- a/modules/compute/virtual_machine/managed_identities.tf
+++ b/modules/compute/virtual_machine/managed_identities.tf
@@ -17,10 +17,7 @@ locals {
     ]
   ])
 
-  # Hard-coded Sentinel AMA UMI resource ID (Serco specific)
-  sentinel_ama_identity = ["/subscriptions/e65cade2-f04d-4cbc-b5cb-aa59cf2d5088/resourceGroups/rg-sga3p-slg-sentinel/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-sgp-slg-ama-win"]
-
   provided_identities = try(var.settings.virtual_machine_settings[local.os_type].identity.managed_identity_ids, [])
 
-  managed_identities = concat(local.sentinel_ama_identity, local.provided_identities, local.managed_local_identities, local.managed_remote_identities)
+  managed_identities = concat(local.provided_identities, local.managed_local_identities, local.managed_remote_identities)
 }

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -238,7 +238,8 @@ resource "azurerm_linux_virtual_machine" "vm" {
       os_disk[0].name, #for ASR disk restores
       admin_ssh_key,
       admin_password,
-      admin_username
+      admin_username,
+      identity # Identities ignored for Sentinel AMA UMI (Serco specific)
     ]
   }
 

--- a/modules/compute/virtual_machine/vm_linux.tf
+++ b/modules/compute/virtual_machine/vm_linux.tf
@@ -239,7 +239,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
       admin_ssh_key,
       admin_password,
       admin_username,
-      identity # Identities ignored for Sentinel AMA UMI (Serco specific)
+      identity # Identities ignored for Sentinel AMA UMI
     ]
   }
 

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -185,7 +185,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
       os_disk[0].name, # For ASR disk restores
       admin_username,  # Only used for initial deployment as it can be changed later by GPO
       admin_password,  # Only used for initial deployment as it can be changed later by GPO
-      identity[0]      # Hard-coded Sentinel AMA UMI (Serco specific)
+      identity         # Identities ignored for Sentinel AMA UMI (Serco specific)
     ]
   }
 }

--- a/modules/compute/virtual_machine/vm_windows.tf
+++ b/modules/compute/virtual_machine/vm_windows.tf
@@ -185,7 +185,7 @@ resource "azurerm_windows_virtual_machine" "vm" {
       os_disk[0].name, # For ASR disk restores
       admin_username,  # Only used for initial deployment as it can be changed later by GPO
       admin_password,  # Only used for initial deployment as it can be changed later by GPO
-      identity         # Identities ignored for Sentinel AMA UMI (Serco specific)
+      identity         # Identities ignored for Sentinel AMA UMI
     ]
   }
 }


### PR DESCRIPTION
Ignore identities on VMs to accommodate the ID added by policy for Sentinel AMA