### PR TITLE
Dfh verint

### DIFF
--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -379,6 +379,12 @@ resource "azurerm_application_gateway" "agw" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      ssl_certificate,
+    ]
+  }
 }
 
 output "certificate_keys" {

--- a/modules/networking/application_gateway/application_gateway.tf
+++ b/modules/networking/application_gateway/application_gateway.tf
@@ -382,6 +382,7 @@ resource "azurerm_application_gateway" "agw" {
 
   lifecycle {
     ignore_changes = [
+      http_listener,
       ssl_certificate,
     ]
   }


### PR DESCRIPTION
Ignore changes to ssl_certs and http_listeners on application gateways. 
API reports these in a different order on each call resulting in redeployment.